### PR TITLE
Representation of manager.ManagerMsg was fixed

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -124,8 +124,12 @@ class ManagerMsg(object):
     def __getitem__(self, hname):
         """Return the specfied header"""
         return self.headers[hname]
+
     def __repr__(self):
-        return self.headers['Response']
+        if 'Response' in self.headers:
+            return self.headers['Response']
+        else:
+            return self.headers['Event']
 
 
 class Event(object):


### PR DESCRIPTION
The point is that there often can be a situation during event handling when the Event header is parsed and Request header is not parsed. In this situation, instead of raising KeyError in the ManagerMsg.**repr**, header['event'] should be returned.
