### PR TITLE
Fix multiline response. Now based on EventList header.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ __pycache__/
 
 # Auto-generated files.
 MANIFEST
+
+# IDE
+.idea

--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -333,11 +333,9 @@ class Manager(object):
                             break
                         # ignore empty lines at start
                         continue
-                    # If the user executed the status command, it's a special
+                    # If the user executed the status command or other
+                    # command with multiline response, it's a special
                     # case, so we need to look for a marker.
-                    # if 'status will follow' in line:
-                    #     status = True
-                    #     wait_for_marker = True
                     if 'EventList: start' in line:
                         status = True
                         wait_for_marker = True
@@ -356,10 +354,7 @@ class Manager(object):
                     if multiline and (line.startswith('--END COMMAND--') or line.strip().endswith('--END COMMAND--')):
                         wait_for_marker = False
                         multiline = False
-                    # same when seeing end of status response
-                    # if status and 'StatusComplete' in line:
-                    #     wait_for_marker = False
-                    #     status = False
+                    # same when seeing end of status of multiline response
                     if status and 'EventList: Complete' in line:
                         wait_for_marker = False
                         status = False

--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -335,7 +335,10 @@ class Manager(object):
                         continue
                     # If the user executed the status command, it's a special
                     # case, so we need to look for a marker.
-                    if 'status will follow' in line:
+                    # if 'status will follow' in line:
+                    #     status = True
+                    #     wait_for_marker = True
+                    if 'EventList: start' in line:
                         status = True
                         wait_for_marker = True
                     lines.append(line)
@@ -354,7 +357,10 @@ class Manager(object):
                         wait_for_marker = False
                         multiline = False
                     # same when seeing end of status response
-                    if status and 'StatusComplete' in line:
+                    # if status and 'StatusComplete' in line:
+                    #     wait_for_marker = False
+                    #     status = False
+                    if status and 'EventList: Complete' in line:
                         wait_for_marker = False
                         status = False
                     if not self._connected.isSet():


### PR DESCRIPTION
Current version of pyst2 (0.5.1) doesn't parse correctly all multiline responses. In this case for example: actions CoreShowChannels or BridgeList. There is no Events in response. Issue persists in asterisk versions 16.7.0 - 16.9.0 (tested on these versions). Small fix in this pull request might resolve this issue.
Fixes #35 