### PR TITLE
Fix: Checks if socket is not closed before calling flush()

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -283,7 +283,9 @@ class Manager(object):
         # lock the socket and send our command
         try:
             self._sock.write(command.encode('utf8','ignore'))
-            self._sock.flush()
+            # Check if The socket is already closed. May happen after sending "Action: Logoff"
+            if not self._sock.closed:
+                self._sock.flush()
         except socket.error as e:
             raise ManagerSocketException(e.errno, e.strerror)
 


### PR DESCRIPTION
- If the socket is already closed, do not call flush()
- Fixes [#50 ](https://github.com/rdegges/pyst2/issues/50)
