### PR TITLE
fix documentation, typos

### DIFF
--- a/asterisk/agi.py
+++ b/asterisk/agi.py
@@ -424,7 +424,7 @@ class AGI:
 
     def say_datetime(self, seconds, escape_digits='', format='', zone=''):
         """agi.say_datetime(seconds, escape_digits='', format='', zone='') --> digit
-        Say a given date in the format specfied (see voicemail.conf), returning
+        Say a given date in the format specified (see voicemail.conf), returning
         early if any of the given DTMF digits are pressed.  The date should be
         in seconds since the UNIX Epoch (Jan 1, 1970 00:00:00).
         """

--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -139,11 +139,11 @@ class ManagerMsg(object):
         return hname in self.headers
 
     def get_header(self, hname, defval=None):
-        """Return the specfied header"""
+        """Return the specified header"""
         return self.headers.get(hname, defval)
 
     def __getitem__(self, hname):
-        """Return the specfied header"""
+        """Return the specified header"""
         return self.headers[hname]
 
     def __repr__(self):
@@ -154,7 +154,7 @@ class ManagerMsg(object):
 
 
 class Event(object):
-    """Manager interface Events, __init__ expects and 'Event' message"""
+    """Manager interface Events, __init__ expects a 'ManagerMsg' message"""
     def __init__(self, message):
 
         # store all of the event data
@@ -175,11 +175,11 @@ class Event(object):
         return hname in self.headers
 
     def get_header(self, hname, defval=None):
-        """Return the specfied header"""
+        """Return the specified header"""
         return self.headers.get(hname, defval)
 
     def __getitem__(self, hname):
-        """Return the specfied header"""
+        """Return the specified header"""
         return self.headers[hname]
 
     def __repr__(self):
@@ -375,7 +375,7 @@ class Manager(object):
 
     def register_event(self, event, function):
         """
-        Register a callback for the specfied event.
+        Register a callback for the specified event.
         If a callback function returns True, no more callbacks for that
         event will be executed.
         """
@@ -614,7 +614,7 @@ class Manager(object):
         return response
 
     def mailbox_status(self, mailbox):
-        """Get the status of the specfied mailbox"""
+        """Get the status of the specified mailbox"""
 
         cdict = {'Action': 'MailboxStatus'}
         cdict['Mailbox'] = mailbox


### PR DESCRIPTION
fixes spelling of specified, and fixes the documentation of Event.__init__ which takes a ManagerMsg, not another Event object