### PR TITLE
ignore socket exceptions when closing so we don't fail to terminate t…

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -500,7 +500,11 @@ class Manager(object):
 
         # if we are still running, logout
         if self._running.isSet() and self._connected.isSet():
-            self.logoff()
+            try:
+                self.logoff()
+            except ManagerSocketException:
+                self._connected.clear()
+                pass
 
         if self._running.isSet():
             # put None in the message_queue to kill our threads


### PR DESCRIPTION
…he threads

if the connection gets killed early by some other process, the act of trying to send the logout command will raise an exception that prevents the rest of the close method from executing, which leaks threads.