### PR TITLE
Added timeout to connection function

### DIFF
--- a/asterisk/manager.py
+++ b/asterisk/manager.py
@@ -458,7 +458,7 @@ class Manager(object):
                 if callback(ev, self):
                     break
 
-    def connect(self, host, port=5038, buffer_size=0):
+    def connect(self, host, port=5038, buffer_size=0, timeout=60):
         """Connect to the manager interface"""
 
         if self._connected.isSet():
@@ -473,6 +473,7 @@ class Manager(object):
         # create our socket and connect
         try:
             _sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+            _sock.settimeout(timeout)
             _sock.connect((host, port))
             if PY3:
                 self._sock = _sock.makefile(mode='rwb', buffering=buffer_size)


### PR DESCRIPTION
Added timeout arg to connection function to make it posible to set timeout for ami connection. It is important in case if we have to send ami action not in main thread. In main thread we can use signals to limit connection time, but in child thread we can only use socket's timeout.