### PR TITLE
Change def send_command to utf8 mode

### DIFF
--- a/asterisk/agi.py
+++ b/asterisk/agi.py
@@ -163,7 +163,7 @@ class AGI:
         if command[-1] != '\n':
             command += '\n'
         self.stderr.write('    COMMAND: %s' % command)
-        self.stdout.write(command)
+        self.stdout.write(command.encode('utf8'))
         self.stdout.flush()
 
     def get_result(self, stdin=sys.stdin):


### PR DESCRIPTION
I've made this modification in your function


> def send_command(self, command, *args):
>         """Send a command to Asterisk"""
>         command = command.strip()
>         command = '%s %s' % (command, ' '.join(map(str, args)))
>         command = command.strip()
>         if command[-1] != '\n':
>             command += '\n'
>         self.stderr.write('    COMMAND: %s' % command)
>         **self.stdout.write(command.encode('utf8'))**
>         self.stdout.flush()

        
it's compatible with python 3.13
        
Without this change, the python3 script doesn't work

https://stackoverflow.com/questions/76745686/asterisk-fastagi-pyst2-python3/76747046#76747046